### PR TITLE
Make release workflow publish WASM package to NPM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
       - name: Check formatting
         run: cargo fmt --check
       - name: Clippy
@@ -34,5 +35,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
       - name: Build WASM
         run: cargo build --target wasm32-unknown-unknown -p brarchive-wasm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }} -p brarchive-cli
@@ -73,6 +74,7 @@ jobs:
           node-version: '24.x'
           package-manager-cache: false
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build WASM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -67,6 +68,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          package-manager-cache: false
       - uses: dtolnay/rust-toolchain@stable
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -77,6 +82,8 @@ jobs:
           VERSION=${GITHUB_REF_NAME#v}
           cd wasm/pkg && zip -r ../../brarchive-v${VERSION}-wasm.zip .
           echo "ASSET=brarchive-v${VERSION}-wasm.zip" >> $GITHUB_ENV
+      - name: Publish to NPM
+        run: npm publish wasm/pkg --provenance --access public
       - uses: actions/upload-artifact@v4
         with:
           name: wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "brarchive-wasm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "brarchive",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ resolver = "2"
 
 [profile.release]
 lto = true
+codegen-units = 1

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["data-structures", "parser-implementations", "command-line-utiliti
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-brarchive = { path = "../lib", version = "0.2.0" }
+brarchive = { path = "../lib", version = "0.2.1" }
 log = "0.4"
 fern = { version = "0.7", features = ["colored"] }
 chrono = "0.4"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brarchive-wasm"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["theaddonn <theaddonn@gmail.com>"]
 description = "WASM bindings for brarchive"


### PR DESCRIPTION
...and a couple other small changes.

For obvious reasons I haven't been able to test this out myself so it will probably require some fixing once merged.

This relies on using NPM trusted publishing which is configured in the NPM package settings. More info: https://docs.npmjs.com/trusted-publishers

Also - I'm not sure if this is possible but could the crate versions be put in the root Cargo.toml rather than duplicated in all three?